### PR TITLE
Optionally write dot graph of dependencies

### DIFF
--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/config/Config.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/config/Config.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.twitter.classpathverifier
+package com.twitter.classpathverifier.config
 
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
+import com.twitter.classpathverifier.Reference
 import com.twitter.classpathverifier.diagnostics.Reporter
 import com.twitter.classpathverifier.jdk.JavaHome
 import com.twitter.classpathverifier.linker.Constants
@@ -27,12 +28,13 @@ import com.twitter.classpathverifier.linker.Context
 import com.twitter.classpathverifier.linker.MethodSummary
 import com.twitter.classpathverifier.linker.Summarizer
 
-case class Config(
+final case class Config(
     javahome: Path,
     classpath: List[Path],
     entrypoints: List[Reference.Method],
     showPaths: Boolean,
-    reporter: Reporter
+    reporter: Reporter,
+    dotConfig: DotConfig
 ) {
   def addJarEntrypoints(jar: Path): Config = {
     val jarEntrypoints = for {
@@ -66,7 +68,15 @@ case class Config(
 }
 
 object Config {
-  def empty: Config = Config(JavaHome.javahome(), Nil, Nil, showPaths = true, Reporter.newReporter)
+  def empty: Config =
+    Config(
+      javahome = JavaHome.javahome(),
+      classpath = Nil,
+      entrypoints = Nil,
+      showPaths = true,
+      reporter = Reporter.newReporter,
+      dotConfig = DotConfig.empty
+    )
 
   def toClasspath(classpath: String): List[Path] =
     classpath

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/config/DotConfig.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/config/DotConfig.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.classpathverifier.config
+
+import java.nio.file.Path
+
+import scopt.Read
+
+final case class DotConfig(
+    output: Option[Path],
+    granularity: DotConfig.Granularity,
+    packageFilter: Set[String]
+)
+
+object DotConfig {
+  sealed trait Granularity
+  object Granularity {
+    case object Package extends Granularity
+    case object Class extends Granularity
+    case object Method extends Granularity
+
+    implicit val GranularityReader: Read[Granularity] =
+      Read.reads(_.toLowerCase match {
+        case "package" => Package
+        case "class"   => Class
+        case "method"  => Method
+        case other     => throw new IllegalArgumentException(s"Unknown granularity: $other")
+      })
+  }
+
+  val empty: DotConfig = DotConfig(
+    output = None,
+    granularity = Granularity.Class,
+    packageFilter = Set.empty
+  )
+}

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/descriptors/Type.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/descriptors/Type.scala
@@ -31,7 +31,7 @@ object Type {
     case object Void extends Primitive
   }
 
-  case class Reference(className: String) extends Type
+  case class Reference(fullName: String) extends Type
   case class Array(tpe: Type) extends Type
 
   def pathToName(path: String): String =

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/dot/DotBuffer.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/dot/DotBuffer.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.classpathverifier.dot
+
+import java.nio.file.Files
+import java.util.concurrent.ConcurrentHashMap
+import java.util.{ Set => JSet }
+
+import com.twitter.classpathverifier.Reference
+import com.twitter.classpathverifier.config.DotConfig
+import com.twitter.classpathverifier.config.DotConfig.Granularity
+import com.twitter.classpathverifier.linker.Context
+
+trait DotBuffer {
+  def addDependency(to: Reference)(implicit ctx: Context): Unit
+  def markMissing(ref: Reference): Unit
+  def writeGraph(): Unit
+}
+
+object DotBuffer {
+  def apply(config: DotConfig): DotBuffer =
+    if (config.output.isDefined) new DefaultDotBuffer(config)
+    else NoDotBuffer
+
+  class Buffer[T] {
+    private val items = new ConcurrentHashMap[T, JSet[T]]
+    def add(key: T, value: T): Unit = {
+      if (key != value) {
+        val values = items.computeIfAbsent(key, _ => ConcurrentHashMap.newKeySet[T]())
+        values.add(value)
+      }
+    }
+    def foreach(op: (T, T) => Unit): Unit =
+      items.forEach { (key, values) =>
+        values.forEach { value => op(key, value) }
+      }
+  }
+}
+
+object NoDotBuffer extends DotBuffer {
+  override def addDependency(to: Reference)(implicit ctx: Context): Unit = ()
+  override def markMissing(ref: Reference): Unit = ()
+  override def writeGraph(): Unit = ()
+}
+
+private class DefaultDotBuffer(config: DotConfig) extends DotBuffer {
+  private val granularity = config.granularity
+  private val dependencies = new DotBuffer.Buffer[String]
+  private val missingRefs: JSet[String] = ConcurrentHashMap.newKeySet[String]
+  private val includedPackages: JSet[String] = ConcurrentHashMap.newKeySet[String]
+  private val excludedPackages: JSet[String] = ConcurrentHashMap.newKeySet[String]
+
+  override def addDependency(to: Reference)(implicit ctx: Context): Unit = {
+    val currentPackage = ctx.currentMethod.packageName
+    val included = isIncluded(ctx.currentMethod) && isIncluded(to)
+
+    if (included) {
+      granularity match {
+        case Granularity.Package =>
+          dependencies.add(currentPackage, to.packageName)
+        case Granularity.Class =>
+          dependencies.add(ctx.currentMethod.fullClassName, to.fullClassName)
+        case Granularity.Method =>
+          dependencies.add(ctx.currentMethod.show, to.show)
+      }
+    }
+  }
+  override def markMissing(ref: Reference): Unit = {
+    if (isIncluded(ref)) {
+      val key = granularity match {
+        case Granularity.Package => ref.packageName
+        case Granularity.Class   => ref.fullClassName
+        case Granularity.Method  => ref.show
+      }
+      missingRefs.add(key)
+    }
+  }
+  override def writeGraph(): Unit =
+    config.output.foreach { output =>
+      val buffer = new StringBuilder()
+      buffer.append("digraph {\n")
+      missingRefs.forEach { ref =>
+        buffer.append(s"""\t"$ref" [fillcolor=red style=filled];\n""")
+      }
+      dependencies.foreach { (from, to) =>
+        buffer.append(s"""\t"$from" -> "$to";\n""")
+      }
+      buffer.append("}\n")
+      Files.write(output, buffer.toString.getBytes)
+    }
+
+  private def isIncluded(ref: Reference): Boolean = {
+    val currentPackage = ref.packageName
+    if (config.packageFilter.isEmpty) true
+    else if (includedPackages.contains(currentPackage)) true
+    else if (excludedPackages.contains(currentPackage)) false
+    else if (
+      config.packageFilter.contains(currentPackage) || config.packageFilter
+        .exists(x => currentPackage.startsWith(x + "."))
+    ) {
+      includedPackages.add(currentPackage)
+      true
+    } else {
+      excludedPackages.add(currentPackage)
+      false
+    }
+  }
+
+}

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/ClassSummary.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/ClassSummary.scala
@@ -115,13 +115,13 @@ object ClassSummary {
       if (isInterface) ClassKind.Interface
       else if (isAbstract) ClassKind.AbstractClass
       else ClassKind.Class
-    ClassSummary(kind, Type.pathToName(visitor.className), parent, interfaces, methods)
+    ClassSummary(kind, Type.pathToName(visitor.fullName), parent, interfaces, methods)
   }
 
   private class Visitor(buffer: Buffer[MethodSummary]) extends ClassVisitor(Opcodes.ASM9) {
 
-    private var myClassName: String = _
-    def className: String = myClassName
+    private var myFullName: String = _
+    def fullName: String = myFullName
 
     override def visit(
         version: Int,
@@ -131,7 +131,7 @@ object ClassSummary {
         superName: String,
         interfaces: Array[String]
     ): Unit = {
-      myClassName = name
+      myFullName = name
       super.visit(version, access, name, signature, superName, interfaces)
     }
 
@@ -146,7 +146,7 @@ object ClassSummary {
       val callback = (deps: List[Dependency]) => {
         val summary =
           MethodSummary(
-            Type.pathToName(myClassName),
+            Type.pathToName(myFullName),
             name,
             Type.pathToName(descriptor),
             deps,

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/Context.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/Context.scala
@@ -16,14 +16,17 @@
 
 package com.twitter.classpathverifier.linker
 
-import com.twitter.classpathverifier.Config
 import com.twitter.classpathverifier.Reference
+import com.twitter.classpathverifier.config.Config
 import com.twitter.classpathverifier.diagnostics.Reporter
+import com.twitter.classpathverifier.dot.DotBuffer
+import com.twitter.classpathverifier.dot.NoDotBuffer
 
 case class Context(
     parent: Context,
     config: Config,
-    currentMethod: Reference.Method
+    currentMethod: Reference.Method,
+    dot: DotBuffer
 ) {
   def in(ref: Reference.Method): Context =
     copy(parent = this, currentMethod = ref)
@@ -38,7 +41,7 @@ case class Context(
 }
 
 object Context {
-
-  object RootContext extends Context(null, Config.empty, Reference.Method.NoMethod)
-  def init(config: Config): Context = Context(RootContext, config, Reference.Method.NoMethod)
+  object RootContext extends Context(null, Config.empty, Reference.Method.NoMethod, NoDotBuffer)
+  def init(config: Config): Context =
+    Context(RootContext, config, Reference.Method.NoMethod, DotBuffer(config.dotConfig))
 }

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/Dependency.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/Dependency.scala
@@ -27,7 +27,7 @@ case class ClassDependency(ref: Reference.Clazz) extends Dependency
 sealed trait MethodDependency extends Dependency {
   type Dep <: Dependency
   def ref: Reference.Method
-  def inClass(className: String): Dep
+  def inClass(fullName: String): Dep
 }
 
 object MethodDependency {
@@ -35,11 +35,11 @@ object MethodDependency {
   case class Static(ref: Reference.Method) extends MethodDependency {
     type Dep = Static
     def dynamic: Dynamic = Dynamic(ref)
-    override def inClass(className: String): Dep = copy(ref = ref.copy(className = className))
+    override def inClass(fullName: String): Dep = copy(ref = ref.copy(fullClassName = fullName))
   }
   case class Dynamic(ref: Reference.Method) extends MethodDependency {
     type Dep = Dynamic
     def static: Static = Static(ref)
-    override def inClass(className: String): Dep = copy(ref = ref.copy(className = className))
+    override def inClass(fullName: String): Dep = copy(ref = ref.copy(fullClassName = fullName))
   }
 }

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/MethodFinder.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/MethodFinder.scala
@@ -32,7 +32,7 @@ class MethodFinder(classpath: List[Path]) {
 
   def find(entrypoint: Reference.Method): Option[MethodVisitor] =
     classFinder
-      .find(entrypoint.className)
+      .find(entrypoint.fullClassName)
       .map { clazz =>
         val reader = new ClassReader(clazz)
         val descriptor = Type.nameToPath(entrypoint.descriptor)

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/MethodSummary.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/MethodSummary.scala
@@ -25,19 +25,19 @@ import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
 sealed case class MethodSummary(
-    className: String,
+    fullClassName: String,
     methodName: String,
     descriptor: String,
     dependencies: List[Dependency],
     isAbstract: Boolean
 ) {
-  def ref: Reference.Method = Reference.Method(className, methodName, descriptor)
+  def ref: Reference.Method = Reference.Method(fullClassName, methodName, descriptor)
 }
 
 object MethodSummary {
   object Empty
       extends MethodSummary(
-        className = "",
+        fullClassName = "",
         methodName = "",
         descriptor = "",
         dependencies = Nil,
@@ -88,7 +88,7 @@ object MethodSummary {
       val owner = actualOwner(rawOwner)
       val reference = new Reference.Method(owner, name, Type.pathToName(descriptor))
       if (name == Constants.InitMethod) {
-        val clazzReference = new Reference.Clazz(owner)
+        val clazzReference = Reference.Clazz(owner)
         dependencies += ClassDependency(clazzReference)
       }
       dependencies += MethodDependency.Static(reference)
@@ -101,7 +101,7 @@ object MethodSummary {
       super.visitTypeInsn(opcode, classType)
       if (opcode != Opcodes.ANEWARRAY) {
         val tpe = actualOwner(classType)
-        val reference = new Reference.Clazz(tpe)
+        val reference = Reference.Clazz(tpe)
         dependencies += new ClassDependency(reference)
       }
     }

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/PathFinder.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/PathFinder.scala
@@ -52,7 +52,7 @@ private class PathFinder(summarize: Summarizer) {
   }
 
   private def dependencies(ref: Reference.Method)(implicit ctx: Context): List[Reference.Method] = {
-    summarize(ref.className)
+    summarize(ref.fullClassName)
       .resolveDep(summarize, MethodDependency.Static(ref))
       .getOrElse(MethodSummary.Empty)
       .dependencies

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/dot/DotBufferSuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/dot/DotBufferSuite.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.classpathverifier.dot
+
+import java.nio.file.Path
+
+import scala.collection.mutable.LinkedHashSet
+
+import com.twitter.classpathverifier.Reference
+import com.twitter.classpathverifier.config.Config
+import com.twitter.classpathverifier.linker.BaseLinkerSuite
+import com.twitter.classpathverifier.linker.Context
+import com.twitter.classpathverifier.linker.Linker
+import com.twitter.classpathverifier.testutil.Build
+import com.twitter.classpathverifier.testutil.Project
+import com.twitter.classpathverifier.testutil.TestBuilds
+class DotBufferSuite extends BaseLinkerSuite {
+
+  testGraphOf(TestBuilds.inherited, """new test.Child().baz()""") { obtainedEvents =>
+    val expectedEvents = List(
+      AddDependency(Reference.Method.NoMethod, methRef("test.main.Main")),
+      AddDependency(methRef("test.main.Main"), classRef("test.Child")),
+      AddDependency(methRef("test.main.Main"), methRef("test.Child#<init>:()V")),
+      AddDependency(methRef("test.main.Main"), methRef("test.Child#baz:()I")),
+      AddDependency(methRef("test.main.Main"), classRef("test.Middle")),
+      AddDependency(methRef("test.main.Main"), classRef("test.ChildInterface")),
+      AddDependency(methRef("test.Child#<init>:()V"), methRef("test.Middle#<init>:()V")),
+      AddDependency(methRef("test.Child#baz:()I"), methRef("test.Child#bar:()I")),
+      AddDependency(methRef("test.Child#baz:()I"), methRef("test.Child#foo:()I")),
+      AddDependency(methRef("test.main.Main"), classRef("test.Parent")),
+      AddDependency(methRef("test.main.Main"), classRef("test.MiddleInterface")),
+      AddDependency(methRef("test.main.Main"), classRef("java.lang.Object")),
+      AddDependency(methRef("test.Middle#<init>:()V"), methRef("test.Parent#<init>:()V")),
+      AddDependency(methRef("test.Middle#bar:()I"), methRef("test.Middle#foo:()I")),
+      AddDependency(methRef("test.main.Main"), classRef("test.ParentInterface")),
+      AddDependency(methRef("test.Parent#<init>:()V"), methRef("java.lang.Object#<init>:()V"))
+    )
+    assertEquals(obtainedEvents, expectedEvents)
+  }
+
+  testGraphOf(TestBuilds.testValueType, """test.Main.typeCheck(null)""") { obtainedEvents =>
+    val expectedEvents = List(
+      AddDependency(Reference.Method.NoMethod, methRef("test.main.Main")),
+      AddDependency(
+        methRef("test.main.Main"),
+        methRef("test.Main$#typeCheck:(Ljava.lang.Object;)Z")
+      ),
+      AddDependency(
+        methRef("test.Main$#typeCheck:(Ljava.lang.Object;)Z"),
+        classRef("test.TheClass")
+      ),
+      AddDependency(
+        methRef("test.Main$#typeCheck:(Ljava.lang.Object;)Z"),
+        classRef("java.lang.Object")
+      )
+    )
+    assertEquals(obtainedEvents, expectedEvents)
+  }
+
+  testBrokenGraphOf(TestBuilds.renameMethod, "test.Main$#proxy0:()I") { obtainedEvents =>
+    val expectedEvents = List(
+      AddDependency(Reference.Method.NoMethod, methRef("test.Main$#proxy0:()I")),
+      AddDependency(methRef("test.Main$#proxy0:()I"), methRef("test.Library$#originalMethod:()I")),
+      Missing(methRef("test.Library$#originalMethod:()I"))
+    )
+    assertEquals(obtainedEvents, expectedEvents)
+  }
+
+  private def testBrokenGraphOf(build: Build, entrypoint: String)(op: List[DotEvent] => Unit) =
+    test(s"Graph of ${build.name}: `$entrypoint`") {
+      val events = dotEvents(build.brokenMainClasspath, entrypoint)
+      op(events)
+    }
+
+  private def testGraphOf(build: Build, code: String)(
+      op: List[DotEvent] => Unit
+  )(implicit loc: munit.Location): Unit =
+    test(s"Graph of ${build.name}: `$code`") {
+      val testProj = Project("test-project")
+        .withSource(s"""|package test
+                        |package main
+                        |class Main {
+                        |  def main(args: Array[String]): Unit = { $code }
+                        |}""".stripMargin)
+        .dependsOn(build)
+      val testBuild = Build("test-build", testProj)
+      val classpath = testBuild.classpath("test-project").full
+      val events = dotEvents(classpath, "test.main.Main")
+      op(events)
+    }
+
+  private def dotEvents(classpath: List[Path], entrypoint: String): List[DotEvent] = {
+    val config =
+      Config.empty.copy(classpath = classpath, entrypoints = List(methRef(entrypoint)))
+    val buffer = new TestDotBuffer
+    val ctx = Context.init(config).copy(dot = buffer)
+    Linker.verify(ctx)
+    buffer.events.toList
+  }
+
+  private class TestDotBuffer extends DotBuffer {
+    val events: LinkedHashSet[DotEvent] = LinkedHashSet.empty
+    override def addDependency(to: Reference)(implicit ctx: Context): Unit =
+      events += AddDependency(ctx.currentMethod, to)
+    override def markMissing(ref: Reference): Unit = events += Missing(ref)
+    override def writeGraph(): Unit = ()
+  }
+
+  private sealed trait DotEvent
+  private case class AddDependency(from: Reference, to: Reference) extends DotEvent
+  private case class Missing(ref: Reference) extends DotEvent
+}

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/BaseLinkerSuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/BaseLinkerSuite.scala
@@ -16,16 +16,18 @@
 
 package com.twitter.classpathverifier.linker
 
-import com.twitter.classpathverifier.Config
 import com.twitter.classpathverifier.Reference
+import com.twitter.classpathverifier.config.Config
 import com.twitter.classpathverifier.testutil.FailingReporter
 
 abstract class BaseLinkerSuite extends munit.FunSuite {
   def methDep(r: String): MethodDependency.Static =
-    MethodDependency.Static(Reference.Method(r).getOrElse(fail(s"Cannot parse: '$r'")))
+    MethodDependency.Static(methRef(r))
   def classDep(name: String): ClassDependency = ClassDependency(classRef(name))
   def classRef(name: String): Reference.Clazz =
     Reference.Clazz(name)
+  def methRef(spec: String): Reference.Method =
+    Reference.Method(spec).getOrElse(fail(s"Cannot parse: '$spec'"))
 
   val failOnError: Context =
     Context.init(Config.empty.copy(reporter = new FailingReporter((msg: String) => fail(msg))))

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/ClassSummarySuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/ClassSummarySuite.scala
@@ -190,7 +190,7 @@ class ClassSummarySuite extends BaseLinkerSuite with Summary {
 
   private def comparableMethodSummaries(methods: List[MethodSummary]): List[MethodSummary] =
     methods.map(comparableMethodSummary).sortBy { method =>
-      (method.className, method.methodName, method.descriptor, method.isAbstract)
+      (method.fullClassName, method.methodName, method.descriptor, method.isAbstract)
     }
 
   private def comparableMethodSummary(summary: MethodSummary): MethodSummary =


### PR DESCRIPTION
This commit introduces a new option `--dot-output <path>` which defines
the path where to write a dot graph representing the dependencies
between methods, classes or packages of the application.

Whether the graph should represent dependencies between methods, classes
or packages can be configured with `--dot-granularity <granularity>`.

The packages included in the produced dot graph can be filtered using
`--dot-package-filter <package>`. When set, symbols belonging to
`<package>` or any of its subpackages will be included in the dot graph.