### PR TITLE
Fix memory and file descriptor leaks

### DIFF
--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/io/Managed.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/io/Managed.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.classpathverifier.io
+
+trait Managed[T] { self =>
+  def use[U](op: T => U): U
+
+  def map[Z](fn: T => Z): Managed[Z] =
+    new Managed[Z] {
+      override def use[U](op: Z => U): U = self.use(t => op(fn(t)))
+    }
+
+  def flatMap[Z](fn: T => Managed[Z]): Managed[Z] =
+    new Managed[Z] {
+      override def use[U](op: Z => U): U = self.use(t => fn(t).use(op))
+    }
+
+  def foreach(op: T => Unit): Unit = use(op)
+}
+
+object Managed {
+
+  private def create[T](materialize: => T, close: T => Unit): Managed[T] =
+    new Managed[T] {
+      override def use[U](op: T => U): U = {
+        val resource = materialize
+        try op(resource)
+        finally if (resource != null) close(resource)
+      }
+    }
+
+  def apply[T](materialize: => T)(close: T => Unit): Managed[T] =
+    create(materialize, close)
+
+  def apply[T <: AutoCloseable](materialize: => T): Managed[T] =
+    create(materialize, _.close())
+
+  def wrap[T](value: T): Managed[T] = apply(value)(_ => ())
+
+}

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/jdk/JavaHome.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/jdk/JavaHome.scala
@@ -17,19 +17,24 @@
 package com.twitter.classpathverifier.jdk
 
 import java.net.URI
+import java.net.URLClassLoader
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.{ Stream => JStream }
 
 import scala.jdk.CollectionConverters._
 
+import com.twitter.classpathverifier.io.Managed
+
 object JavaHome {
 
   private val versionRegex = s"""JAVA_VERSION=["']?(.+?)["']?$$""".r
+  private val jreClasspathCache = new ConcurrentHashMap[Path, List[Path]]()
 
   def javahome(): Path = Paths.get(sys.props("java.home"))
 
@@ -39,11 +44,15 @@ object JavaHome {
     else None
   }
 
-  def jreClasspathEntries(home: Path): List[Path] = {
-    val jrtfs = home.resolve("lib").resolve("jrt-fs.jar")
-    if (Files.isRegularFile(jrtfs)) classpathEntriesFromJrt(home)
-    else classpathEntriesFromJars(home)
-  }
+  def jreClasspathEntries(home: Path): List[Path] =
+    jreClasspathCache.computeIfAbsent(
+      home,
+      _ => {
+        val jrtfs = home.resolve("lib").resolve("jrt-fs.jar")
+        if (Files.isRegularFile(jrtfs)) classpathEntriesFromJrt(home)
+        else classpathEntriesFromJars(home)
+      }
+    )
 
   private def javaVersionFromRelease(release: Path): Option[Int] = {
     Files
@@ -65,27 +74,41 @@ object JavaHome {
         None
     }
 
+  /*
+   * This code is known to leak some memory (it's not about closing the classloader and
+   * filesystem), see:
+   *   - https://bugs.openjdk.java.net/browse/JDK-8260621
+   *   - https://stackoverflow.com/a/68083960/2466911 for a workaround
+   *
+   * This is fixed in JDK 17. We mitigate the issue by caching the classpath entries for each
+   * java home. This shouldn't become an issue unless we load thousands of JRT images in a single
+   * run. Then, a potential solution is to copy all the classfiles from the jrtfs to a known
+   * location, and then use these classfiles.
+   */
   private def classpathEntriesFromJrt(home: Path): List[Path] = {
     val env = Collections.singletonMap("java.home", home.toString)
-    val jrtfs = FileSystems.newFileSystem(URI.create("jrt:/"), env)
+    val jrtfsJar = Array(home.resolve("lib").resolve("jrt-fs.jar").toUri.toURL)
+    val classloader = new URLClassLoader(jrtfsJar)
+    val jrtfs = FileSystems.newFileSystem(URI.create("jrt:/"), env, classloader)
     val modulesRoot = jrtfs.getPath("modules")
-    Files.list(modulesRoot).iterator.asScala.toList.filter(Files.isDirectory(_))
+    Managed(Files.list(modulesRoot)).use(_.iterator.asScala.toList.filter(Files.isDirectory(_)))
   }
 
   private def classpathEntriesFromJars(home: Path): List[Path] = {
     def isJar(file: Path, attrs: BasicFileAttributes): Boolean =
       attrs.isRegularFile() && file.getFileName.toString.endsWith(".jar")
-    def jarsOf(path: Path): JStream[Path] =
-      if (Files.isDirectory(path)) Files.find(path, Int.MaxValue, isJar)
-      else JStream.empty()
+    def jarsOf(path: Path): Managed[JStream[Path]] =
+      Managed {
+        if (Files.isDirectory(path)) Files.find(path, Int.MaxValue, isJar)
+        else JStream.empty()
+      }
 
-    JStream
-      .concat(
-        jarsOf(home.resolve("lib")),
-        jarsOf(home.resolve("jre").resolve("lib"))
-      )
-      .iterator
-      .asScala
-      .toList
+    val entries =
+      for {
+        lib <- jarsOf(home.resolve("lib"))
+        jreLib <- jarsOf(home.resolve("jre").resolve("lib"))
+      } yield JStream.concat(lib, jreLib)
+
+    entries.use(_.iterator.asScala.toList)
   }
 }

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/Linker.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/Linker.scala
@@ -35,13 +35,14 @@ object Linker {
 
   def verify(ctx: Context): Unit = {
     val entrypoints = ctx.config.entrypoints
-    val classpath = ctx.config.fullClasspath
-    val summarizer = new ClassSummarizer(classpath)
-    val linker = new Linker(summarizer)
-    ctx.config.entrypoints.foreach { entrypoint =>
-      linker.verify(entrypoint, ctx)
+    Finder(ctx.config.fullClasspath).use { finder =>
+      val summarizer = new ClassSummarizer(finder)
+      val linker = new Linker(summarizer)
+      ctx.config.entrypoints.foreach { entrypoint =>
+        linker.verify(entrypoint, ctx)
+      }
+      ctx.dot.writeGraph()
     }
-    ctx.dot.writeGraph()
   }
 
 }

--- a/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/MethodFinder.scala
+++ b/classpath-verifier/src/main/scala/com/twitter/classpathverifier/linker/MethodFinder.scala
@@ -28,19 +28,19 @@ import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
 class MethodFinder(classpath: List[Path]) {
-  val classFinder = new ClassFinder(classpath)
+  private val classFinder = new ClassFinder(classpath)
 
   def find(entrypoint: Reference.Method): Option[MethodVisitor] =
     classFinder
       .find(entrypoint.fullClassName)
-      .map { clazz =>
+      .map(_.use { clazz =>
         val reader = new ClassReader(clazz)
         val descriptor = Type.nameToPath(entrypoint.descriptor)
         val visitor =
           new MethodFinderVisitor(entrypoint.methodName, descriptor)
         reader.accept(visitor, 0)
         visitor.results
-      }
+      })
       .getOrElse(Nil) match {
       case Nil =>
         None

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/descriptors/DescriptorSuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/descriptors/DescriptorSuite.scala
@@ -22,6 +22,7 @@ import com.twitter.classpathverifier.jdk.JavaHome
 import com.twitter.classpathverifier.linker.BaseLinkerSuite
 import com.twitter.classpathverifier.linker.ClassSummarizer
 import com.twitter.classpathverifier.linker.Context
+import com.twitter.classpathverifier.linker.Finder
 import com.twitter.classpathverifier.linker.Summarizer
 import com.twitter.classpathverifier.testutil.Build
 import com.twitter.classpathverifier.testutil.TestBuilds
@@ -85,9 +86,10 @@ class DescriptorSuite extends BaseLinkerSuite {
   private def withDescriptors(a: String, b: String, classpath: List[Path])(
       op: (Descriptor, Descriptor, Summarizer) => Unit
   ): Unit = {
-    val summarize = new ClassSummarizer(classpath)
-    val descA = Parser.parse(a)
-    val descB = Parser.parse(b)
-    op(descA, descB, summarize)
+    Finder(classpath).map(new ClassSummarizer(_)).use { summarize =>
+      val descA = Parser.parse(a)
+      val descB = Parser.parse(b)
+      op(descA, descB, summarize)
+    }
   }
 }

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/io/ManagedSuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/io/ManagedSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.classpathverifier.io
+
+import scala.collection.mutable.Buffer
+
+class ManagedSuite extends munit.FunSuite {
+
+  managedTest("managed is not opened unless used", Nil) { rec =>
+    Managed(rec("hello world"))(_ => ())
+  }
+
+  managedTest("managed is closed after use", List("close")) { rec =>
+    Managed(())(_ => rec("close")).use(_ => ())
+  }
+
+  managedTest(
+    "managed is closed after exception",
+    List("open", "throw", "close", "caught: oh no")
+  ) { rec =>
+    try {
+      Managed(rec("open"))(_ => rec("close")).use { _ =>
+        rec("throw")
+        throw new Exception("oh no")
+      }
+    } catch { case ex: Exception => rec("caught: " + ex.getMessage()) }
+  }
+
+  managedTest(
+    "managed.map",
+    List(1, 2, 3, 4, 5)
+  ) { rec =>
+    Managed(rec(1))(_ => rec(5)).map(_ => rec(2)).map(_ => rec(3)).use { _ => rec(4) }
+  }
+
+  managedTest(
+    "managed.map doesn't evaluate",
+    List()
+  ) { rec =>
+    Managed(rec("open"))(_ => rec("close")).map(_ => rec("map"))
+  }
+
+  managedTest(
+    "managed.map throws exception",
+    List("open", "throw", "close", "caught: oh no")
+  ) { rec =>
+    try {
+      Managed(rec("open"))(_ => rec("close"))
+        .map { _ =>
+          rec("throw")
+          throw new Exception("oh no")
+        }
+        .use { (_: Nothing) => rec("unreachable") }
+    } catch { case ex: Exception => rec("caught: " + ex.getMessage) }
+  }
+
+  managedTest(
+    "managed.flatMap",
+    List(1, 2, 3, 4, 5)
+  ) { rec =>
+    Managed(rec(1))(_ => rec(5)).flatMap(_ => Managed(rec(2))(_ => rec(4))).use(_ => rec(3))
+  }
+
+  managedTest(
+    "managed.flatMap throws exception",
+    List("open", "throw", "close", "caught: oh no")
+  ) { rec =>
+    try {
+      Managed(rec("open"))(_ => rec("close"))
+        .flatMap { _ =>
+          rec("throw")
+          throw new Exception("oh no")
+        }
+        .use { (_: Nothing) => rec("unreachable") }
+    } catch { case ex: Exception => rec("caught: " + ex.getMessage) }
+  }
+
+  private def managedTest(name: munit.TestOptions, expectedEvents: List[Any])(
+      body: (Any => Unit) => Unit
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      val buffer = Buffer.empty[Any]
+      body(ev => buffer += ev)
+      assertEquals(buffer.toList, expectedEvents)
+    }
+  }
+
+}

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/ClassFinderSuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/ClassFinderSuite.scala
@@ -26,7 +26,7 @@ class ClassFinderSuite extends BaseLinkerSuite {
     classOf[Map[_, _]]
   ).map(_.getName)
 
-  val finder = new ClassFinder(Resolution.scalaLibrary)
+  private val finder = new ClassFinder(Resolution.scalaLibrary)
 
   classesToFind.foreach { name =>
     test(s"find $name") {

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/ClassSummarySuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/ClassSummarySuite.scala
@@ -172,12 +172,13 @@ class ClassSummarySuite extends BaseLinkerSuite with Summary {
       implicit val ctx: Context = failOnError
       val expectedSummary = summary(className, kind, parent, interfaces)(builder)
       val classpath = build.allClasspath.full
-      val summarizer = new ClassSummarizer(classpath)
-      val obtainedSummary =
-        summarizer(className)
+      Finder(classpath).map(new ClassSummarizer(_)).use { summarizer =>
+        val obtainedSummary =
+          summarizer(className)
 
-      if (BuildInfo.scalaBinaryVersion != "3" || !disableOnScala3) {
-        assertEquals(comparableSummary(obtainedSummary), comparableSummary(expectedSummary))
+        if (BuildInfo.scalaBinaryVersion != "3" || !disableOnScala3) {
+          assertEquals(comparableSummary(obtainedSummary), comparableSummary(expectedSummary))
+        }
       }
     }
   }

--- a/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/PathFinderSuite.scala
+++ b/classpath-verifier/src/test/scala/com/twitter/classpathverifier/linker/PathFinderSuite.scala
@@ -43,10 +43,12 @@ class PathFinderSuite extends BaseLinkerSuite {
     val end = expected.last.ref
     test(s"path: ${start.show} -> ${end.show}") {
       val jreClasses = JavaHome.jreClasspathEntries(JavaHome.javahome())
-      val summarizer = new ClassSummarizer(jreClasses ::: classpath)
-      val obtainedPath = PathFinder.path(summarizer, start, end)
-      val expectedPath = if (expected.isEmpty) None else Some(expected.map(_.ref))
-      assertEquals(obtainedPath, expectedPath)
+      Finder(jreClasses ::: classpath).use { finder =>
+        val summarizer = new ClassSummarizer(finder)
+        val obtainedPath = PathFinder.path(summarizer, start, end)
+        val expectedPath = if (expected.isEmpty) None else Some(expected.map(_.ref))
+        assertEquals(obtainedPath, expectedPath)
+      }
     }
   }
 }


### PR DESCRIPTION
This commit fixes memory and file descriptor leaks by making sure that
we close the JARs that we open, and caching the content of the Java
runtime image that we read.